### PR TITLE
Add AWS Cognito Authentication and made Entry public

### DIFF
--- a/amplify/backend/api/aguadatosamplify/schema.graphql
+++ b/amplify/backend/api/aguadatosamplify/schema.graphql
@@ -20,7 +20,9 @@ enum ChemType {
     ALUMINUM_SULFATE         # Al2(SO4)3: Aluminum Sulfate
 }
 
-type Entry @model(subscriptions: null){
+type Entry
+@model(subscriptions: null)
+@auth(rules: [{ allow: public }]) {
     # General Fields for All Entry Types
 
     # Primary Key (Partition by `plantName#entryType` and Sort by `creationDate`

--- a/amplify/backend/auth/aguadatosamplify89e94c51/cli-inputs.json
+++ b/amplify/backend/auth/aguadatosamplify89e94c51/cli-inputs.json
@@ -1,0 +1,68 @@
+{
+  "version": "1",
+  "cognitoConfig": {
+    "identityPoolName": "aguadatosamplify89e94c51_identitypool_89e94c51",
+    "allowUnauthenticatedIdentities": false,
+    "resourceNameTruncated": "aguada89e94c51",
+    "userPoolName": "aguadatosamplify89e94c51_userpool_89e94c51",
+    "autoVerifiedAttributes": [
+      "email"
+    ],
+    "mfaConfiguration": "OFF",
+    "mfaTypes": [
+      "SMS Text Message"
+    ],
+    "smsAuthenticationMessage": "Your authentication code is {####}",
+    "smsVerificationMessage": "Your verification code is {####}",
+    "emailVerificationSubject": "AguaDatos Verification Code",
+    "emailVerificationMessage": "Hello,\n\nThank you for using AguaDatos!\n\nYour AguaDatos verification code is: {####}\n\nBest,\nPlant Operations Smartphone Tracker (POST)\nAguaClara Cornell",
+    "defaultPasswordPolicy": false,
+    "passwordPolicyMinLength": 8,
+    "passwordPolicyCharacters": [
+      "Requires Lowercase",
+      "Requires Numbers",
+      "Requires Symbols",
+      "Requires Uppercase"
+    ],
+    "requiredAttributes": [
+      "email"
+    ],
+    "aliasAttributes": [],
+    "userpoolClientGenerateSecret": false,
+    "userpoolClientRefreshTokenValidity": 30,
+    "userpoolClientWriteAttributes": [],
+    "userpoolClientReadAttributes": [],
+    "userpoolClientLambdaRole": "aguada89e94c51_userpoolclient_lambda_role",
+    "userpoolClientSetAttributes": false,
+    "sharedId": "89e94c51",
+    "resourceName": "aguadatosamplify89e94c51",
+    "authSelections": "identityPoolAndUserPool",
+    "useDefault": "manual",
+    "usernameAttributes": [
+      "email"
+    ],
+    "userPoolGroupList": [],
+    "serviceName": "Cognito",
+    "usernameCaseSensitive": false,
+    "useEnabledMfas": true,
+    "authRoleArn": {
+      "Fn::GetAtt": [
+        "AuthRole",
+        "Arn"
+      ]
+    },
+    "unauthRoleArn": {
+      "Fn::GetAtt": [
+        "UnauthRole",
+        "Arn"
+      ]
+    },
+    "breakCircularDependency": true,
+    "dependsOn": [],
+    "userPoolGroups": false,
+    "adminQueries": false,
+    "thirdPartyAuth": false,
+    "authProviders": [],
+    "hostedUI": false
+  }
+}

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -16,5 +16,38 @@
       "providerPlugin": "awscloudformation",
       "service": "AppSync"
     }
+  },
+  "auth": {
+    "aguadatosamplify89e94c51": {
+      "customAuth": false,
+      "dependsOn": [],
+      "frontendAuthConfig": {
+        "mfaConfiguration": "OFF",
+        "mfaTypes": [
+          "SMS"
+        ],
+        "passwordProtectionSettings": {
+          "passwordPolicyCharacters": [
+            "REQUIRES_LOWERCASE",
+            "REQUIRES_NUMBERS",
+            "REQUIRES_SYMBOLS",
+            "REQUIRES_UPPERCASE"
+          ],
+          "passwordPolicyMinLength": 8
+        },
+        "signupAttributes": [
+          "EMAIL"
+        ],
+        "socialProviders": [],
+        "usernameAttributes": [
+          "EMAIL"
+        ],
+        "verificationMechanisms": [
+          "EMAIL"
+        ]
+      },
+      "providerPlugin": "awscloudformation",
+      "service": "Cognito"
+    }
   }
 }

--- a/amplify/backend/types/amplify-dependent-resources-ref.d.ts
+++ b/amplify/backend/types/amplify-dependent-resources-ref.d.ts
@@ -5,5 +5,16 @@ export type AmplifyDependentResourcesAttributes = {
       "GraphQLAPIIdOutput": "string",
       "GraphQLAPIKeyOutput": "string"
     }
+  },
+  "auth": {
+    "aguadatosamplify89e94c51": {
+      "AppClientID": "string",
+      "AppClientIDWeb": "string",
+      "IdentityPoolId": "string",
+      "IdentityPoolName": "string",
+      "UserPoolArn": "string",
+      "UserPoolId": "string",
+      "UserPoolName": "string"
+    }
   }
 }

--- a/amplify/cli.json
+++ b/amplify/cli.json
@@ -1,64 +1,64 @@
 {
-  "features": {
-    "graphqltransformer": {
-      "addmissingownerfields": true,
-      "improvepluralization": false,
-      "validatetypenamereservedwords": true,
-      "useexperimentalpipelinedtransformer": true,
-      "enableiterativegsiupdates": true,
-      "secondarykeyasgsi": true,
-      "skipoverridemutationinputtypes": true,
-      "transformerversion": 2,
-      "suppressschemamigrationprompt": true,
-      "securityenhancementnotification": false,
-      "showfieldauthnotification": false,
-      "usesubusernamefordefaultidentityclaim": true,
-      "usefieldnameforprimarykeyconnectionfield": false,
-      "enableautoindexquerynames": true,
-      "respectprimarykeyattributesonconnectionfield": true,
-      "shoulddeepmergedirectiveconfigdefaults": false,
-      "populateownerfieldforstaticgroupauth": true,
-      "subscriptionsinheritprimaryauth": false
+    "features": {
+        "graphqltransformer": {
+            "addmissingownerfields": true,
+            "improvepluralization": false,
+            "validatetypenamereservedwords": true,
+            "useexperimentalpipelinedtransformer": true,
+            "enableiterativegsiupdates": true,
+            "secondarykeyasgsi": true,
+            "skipoverridemutationinputtypes": true,
+            "transformerversion": 2,
+            "suppressschemamigrationprompt": true,
+            "securityenhancementnotification": false,
+            "showfieldauthnotification": false,
+            "usesubusernamefordefaultidentityclaim": true,
+            "usefieldnameforprimarykeyconnectionfield": false,
+            "enableautoindexquerynames": true,
+            "respectprimarykeyattributesonconnectionfield": true,
+            "shoulddeepmergedirectiveconfigdefaults": false,
+            "populateownerfieldforstaticgroupauth": true,
+            "subscriptionsinheritprimaryauth": false
+        },
+        "frontend-ios": {
+            "enablexcodeintegration": true
+        },
+        "auth": {
+            "enablecaseinsensitivity": true,
+            "useinclusiveterminology": true,
+            "breakcirculardependency": true,
+            "forcealiasattributes": false,
+            "useenabledmfas": true
+        },
+        "codegen": {
+            "useappsyncmodelgenplugin": true,
+            "usedocsgeneratorplugin": true,
+            "usetypesgeneratorplugin": true,
+            "cleangeneratedmodelsdirectory": true,
+            "retaincasestyle": true,
+            "addtimestampfields": true,
+            "handlelistnullabilitytransparently": true,
+            "emitauthprovider": true,
+            "generateindexrules": true,
+            "enabledartnullsafety": true,
+            "generatemodelsforlazyloadandcustomselectionset": false
+        },
+        "appsync": {
+            "generategraphqlpermissions": true
+        },
+        "latestregionsupport": {
+            "pinpoint": 1,
+            "translate": 1,
+            "transcribe": 1,
+            "rekognition": 1,
+            "textract": 1,
+            "comprehend": 1
+        },
+        "project": {
+            "overrides": true
+        }
     },
-    "frontend-ios": {
-      "enablexcodeintegration": true
-    },
-    "auth": {
-      "enablecaseinsensitivity": true,
-      "useinclusiveterminology": true,
-      "breakcirculardependency": true,
-      "forcealiasattributes": false,
-      "useenabledmfas": true
-    },
-    "codegen": {
-      "useappsyncmodelgenplugin": true,
-      "usedocsgeneratorplugin": true,
-      "usetypesgeneratorplugin": true,
-      "cleangeneratedmodelsdirectory": true,
-      "retaincasestyle": true,
-      "addtimestampfields": true,
-      "handlelistnullabilitytransparently": true,
-      "emitauthprovider": true,
-      "generateindexrules": true,
-      "enabledartnullsafety": true,
-      "generatemodelsforlazyloadandcustomselectionset": false
-    },
-    "appsync": {
-      "generategraphqlpermissions": true
-    },
-    "latestregionsupport": {
-      "pinpoint": 1,
-      "translate": 1,
-      "transcribe": 1,
-      "rekognition": 1,
-      "textract": 1,
-      "comprehend": 1
-    },
-    "project": {
-      "overrides": true
+    "debug": {
+        "shareProjectConfig": false
     }
-  },
-  "debug": {
-    "shareProjectConfig": false
-  }
 }

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -14,6 +14,9 @@
     "categories": {
       "api": {
         "aguadatosamplify": {}
+      },
+      "auth": {
+        "aguadatosamplify89e94c51": {}
       }
     }
   }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,17 +55,15 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 
-
-    //graphs
+    //Graphs
     implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
 
     // Amplify API and Datastore dependencies
     implementation("com.amplifyframework:core:2.19.1") // Core Amplify
-    implementation("com.amplifyframework:aws-api:2.14.11")
-    implementation("com.amplifyframework:aws-datastore:2.14.11")
-    implementation("com.amplifyframework:aws-auth-cognito:1.28.2") // For authentication, if required
+    implementation("com.amplifyframework:aws-api:2.19.1")
+    implementation("com.amplifyframework:aws-datastore:2.19.1")
+    implementation("com.amplifyframework:aws-auth-cognito:2.19.1") // For authentication, if required
     implementation("com.amplifyframework:core-kotlin:2.19.1") // Core Amplify for Coroutines Support
-
 
     // Support for Java 8 features
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.2")

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/Entry.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/Entry.java
@@ -9,7 +9,10 @@ import java.util.Objects;
 
 import androidx.core.util.ObjectsCompat;
 
+import com.amplifyframework.core.model.AuthStrategy;
 import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelOperation;
+import com.amplifyframework.core.model.annotations.AuthRule;
 import com.amplifyframework.core.model.annotations.Index;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
@@ -19,7 +22,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 
 /** This is an auto generated class representing the Entry type in your schema. */
 @SuppressWarnings("all")
-@ModelConfig(pluralName = "Entries", type = Model.Type.USER, version = 1)
+@ModelConfig(pluralName = "Entries", type = Model.Type.USER, version = 1, authRules = {
+  @AuthRule(allow = AuthStrategy.PUBLIC, operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+})
 @Index(name = "undefined", fields = {"plantName","entryType","creationDate"})
 @Index(name = "byOperator", fields = {"operatorName","creationDate"})
 public final class Entry implements Model {

--- a/app/src/main/java/com/example/aguadatosapp/AguadatosAmplify.kt
+++ b/app/src/main/java/com/example/aguadatosapp/AguadatosAmplify.kt
@@ -6,16 +6,19 @@ import com.amplifyframework.AmplifyException
 import com.amplifyframework.api.aws.AWSApiPlugin
 import com.amplifyframework.kotlin.core.Amplify
 import com.amplifyframework.datastore.AWSDataStorePlugin
+import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
 
 /**
  * `AguadatosAmplify` is the main application class responsible for initializing and configuring
  * Amplify framework with DataStore and API plugins on app startup.
  */
-class AguadatosAmplify : Application(){
+class AguadatosAmplify : Application() {
     override fun onCreate() {
         super.onCreate()
 
         try {
+            // Adds AWSAuthPlugin for authorization with AWS services.
+            Amplify.addPlugin(AWSCognitoAuthPlugin())
             // Adds AWSDataStorePlugin for local and cloud data storage.
             Amplify.addPlugin(AWSDataStorePlugin())
             // Adds AWSApiPlugin for API interactions with AWS services.


### PR DESCRIPTION
## Overview
This PR introduces basic AWS Cognito authentication to the application. To prevent authentication issues when other developers run `amplify pull`, the `Entry` type in the GraphQL schema is temporarily set to public.

### Amplify Authentication Configuration
- Initialized the AWS Cognito Auth Plugin in `AguadatosAmplify.kt`.
- Configured authentication to require an `email` and `password` along with an email-based verification code upon sign-up.
- Pushed changes to the Amplify cloud instance and extended existing code to support basic authentication services.

### GraphQL Schema Update
- Added an `@auth` rule to `schema.graphql` to make the `Entry` type publicly accessible.
- Updated the `Entry` model to support public accessibility.

### Dependency Updates
- Updated Amplify dependencies to synchronize library versions.

### Note
- Public access in `schema.graphql` needs to be reverted once authentication is fully implemented and tested.
- Authentication has not yet been integrated into the front end.
