### PR TITLE
Set API key expiration to 365 days, amplify pull

### DIFF
--- a/amplify/backend/api/aguadatosamplify/cli-inputs.json
+++ b/amplify/backend/api/aguadatosamplify/cli-inputs.json
@@ -5,12 +5,15 @@
     "serviceName": "AppSync",
     "defaultAuthType": {
       "mode": "API_KEY",
-      "expirationTime": 7
+      "expirationTime": 365,
+      "apiKeyExpirationDate": "2025-12-31T17:10:33.495Z",
+      "keyDescription": "For accessing the AguaDatos AppSync API"
     },
     "conflictResolution": {
       "defaultResolutionStrategy": {
         "type": "AUTOMERGE"
       }
-    }
+    },
+    "additionalAuthTypes": []
   }
 }

--- a/amplify/backend/api/aguadatosamplify/parameters.json
+++ b/amplify/backend/api/aguadatosamplify/parameters.json
@@ -1,5 +1,6 @@
 {
   "AppSyncApiName": "aguadatosamplify",
   "DynamoDBBillingMode": "PAY_PER_REQUEST",
-  "DynamoDBEnableServerSideEncryption": false
+  "DynamoDBEnableServerSideEncryption": false,
+  "AuthModeLastUpdated": "2024-12-31T17:10:37.077Z"
 }

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -7,7 +7,9 @@
           "additionalAuthenticationProviders": [],
           "defaultAuthentication": {
             "apiKeyConfig": {
-              "apiKeyExpirationDays": 7
+              "apiKeyExpirationDate": "2025-12-31T17:10:33.495Z",
+              "apiKeyExpirationDays": 365,
+              "description": "For accessing the AguaDatos AppSync API"
             },
             "authenticationType": "API_KEY"
           }

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/AmplifyModelProvider.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/AmplifyModelProvider.java
@@ -19,7 +19,7 @@ public final class AmplifyModelProvider implements ModelProvider {
     
   }
   
-  public static AmplifyModelProvider getInstance() {
+  public static synchronized AmplifyModelProvider getInstance() {
     if (amplifyGeneratedModelInstance == null) {
       amplifyGeneratedModelInstance = new AmplifyModelProvider();
     }

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/CalibrationEntry.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/CalibrationEntry.java
@@ -3,6 +3,7 @@ package com.amplifyframework.datastore.generated.model;
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.core.model.annotations.HasOne;
 import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.ModelIdentifier;
 
 import java.util.List;
 import java.util.UUID;
@@ -58,7 +59,9 @@ public final class CalibrationEntry implements Model {
   private final @ModelField(targetType="Operator") @BelongsTo(targetName = "operatorID", targetNames = {"operatorID"}, type = Operator.class) Operator operator;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
   private final @ModelField(targetType="ID") String calibrationEntryDoseEntryId;
-  public String resolveIdentifier() {
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
     return id;
   }
   
@@ -355,6 +358,29 @@ public final class CalibrationEntry implements Model {
     private Plant plant;
     private Operator operator;
     private String calibrationEntryDoseEntryId;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, Temporal.DateTime createdAt, ChemicalType chemicalType, CoagType coagType, Double sliderPosition, Double inflowRate, Double startVolume, Double endVolume, Integer timeElapsed, Double dose, Double flowRate, ActiveTank activeTank, Double tankVolume, Plant plant, Operator operator, String calibrationEntryDoseEntryId) {
+      this.id = id;
+      this.createdAt = createdAt;
+      this.chemicalType = chemicalType;
+      this.coagType = coagType;
+      this.sliderPosition = sliderPosition;
+      this.inflowRate = inflowRate;
+      this.startVolume = startVolume;
+      this.endVolume = endVolume;
+      this.timeElapsed = timeElapsed;
+      this.dose = dose;
+      this.flowRate = flowRate;
+      this.activeTank = activeTank;
+      this.tankVolume = tankVolume;
+      this.plant = plant;
+      this.operator = operator;
+      this.calibrationEntryDoseEntryId = calibrationEntryDoseEntryId;
+    }
+    
     @Override
      public CalibrationEntry build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -490,22 +516,16 @@ public final class CalibrationEntry implements Model {
 
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, Temporal.DateTime createdAt, ChemicalType chemicalType, CoagType coagType, Double sliderPosition, Double inflowRate, Double startVolume, Double endVolume, Integer timeElapsed, Double dose, Double flowRate, ActiveTank activeTank, Double tankVolume, Plant plant, Operator operator, String calibrationEntryDoseEntryId) {
-      super.id(id);
-      super.createdAt(createdAt)
-        .chemicalType(chemicalType)
-        .sliderPosition(sliderPosition)
-        .inflowRate(inflowRate)
-        .startVolume(startVolume)
-        .endVolume(endVolume)
-        .timeElapsed(timeElapsed)
-        .dose(dose)
-        .flowRate(flowRate)
-        .coagType(coagType)
-        .activeTank(activeTank)
-        .tankVolume(tankVolume)
-        .plant(plant)
-        .operator(operator)
-        .calibrationEntryDoseEntryId(calibrationEntryDoseEntryId);
+      super(id, createdAt, chemicalType, coagType, sliderPosition, inflowRate, startVolume, endVolume, timeElapsed, dose, flowRate, activeTank, tankVolume, plant, operator, calibrationEntryDoseEntryId);
+      Objects.requireNonNull(createdAt);
+      Objects.requireNonNull(chemicalType);
+      Objects.requireNonNull(sliderPosition);
+      Objects.requireNonNull(inflowRate);
+      Objects.requireNonNull(startVolume);
+      Objects.requireNonNull(endVolume);
+      Objects.requireNonNull(timeElapsed);
+      Objects.requireNonNull(dose);
+      Objects.requireNonNull(flowRate);
     }
     
     @Override
@@ -581,6 +601,14 @@ public final class CalibrationEntry implements Model {
     @Override
      public CopyOfBuilder calibrationEntryDoseEntryId(String calibrationEntryDoseEntryId) {
       return (CopyOfBuilder) super.calibrationEntryDoseEntryId(calibrationEntryDoseEntryId);
+    }
+  }
+  
+
+  public static class CalibrationEntryIdentifier extends ModelIdentifier<CalibrationEntry> {
+    private static final long serialVersionUID = 1L;
+    public CalibrationEntryIdentifier(String id) {
+      super(id);
     }
   }
   

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/ClarifiedEntry.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/ClarifiedEntry.java
@@ -2,6 +2,7 @@ package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.ModelIdentifier;
 
 import java.util.List;
 import java.util.UUID;
@@ -36,7 +37,9 @@ public final class ClarifiedEntry implements Model {
   private final @ModelField(targetType="Plant") @BelongsTo(targetName = "plantID", targetNames = {"plantID"}, type = Plant.class) Plant plant;
   private final @ModelField(targetType="Operator") @BelongsTo(targetName = "operatorID", targetNames = {"operatorID"}, type = Operator.class) Operator operator;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
-  public String resolveIdentifier() {
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
     return id;
   }
   
@@ -181,6 +184,19 @@ public final class ClarifiedEntry implements Model {
     private String notes;
     private Plant plant;
     private Operator operator;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, Temporal.DateTime createdAt, Double turbidity, String notes, Plant plant, Operator operator) {
+      this.id = id;
+      this.createdAt = createdAt;
+      this.turbidity = turbidity;
+      this.notes = notes;
+      this.plant = plant;
+      this.operator = operator;
+    }
+    
     @Override
      public ClarifiedEntry build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -239,12 +255,9 @@ public final class ClarifiedEntry implements Model {
 
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, Temporal.DateTime createdAt, Double turbidity, String notes, Plant plant, Operator operator) {
-      super.id(id);
-      super.createdAt(createdAt)
-        .turbidity(turbidity)
-        .notes(notes)
-        .plant(plant)
-        .operator(operator);
+      super(id, createdAt, turbidity, notes, plant, operator);
+      Objects.requireNonNull(createdAt);
+      Objects.requireNonNull(turbidity);
     }
     
     @Override
@@ -270,6 +283,14 @@ public final class ClarifiedEntry implements Model {
     @Override
      public CopyOfBuilder operator(Operator operator) {
       return (CopyOfBuilder) super.operator(operator);
+    }
+  }
+  
+
+  public static class ClarifiedEntryIdentifier extends ModelIdentifier<ClarifiedEntry> {
+    private static final long serialVersionUID = 1L;
+    public ClarifiedEntryIdentifier(String id) {
+      super(id);
     }
   }
   

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/DoseEntry.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/DoseEntry.java
@@ -2,6 +2,7 @@ package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.ModelIdentifier;
 
 import java.util.List;
 import java.util.UUID;
@@ -43,7 +44,9 @@ public final class DoseEntry implements Model {
   private final @ModelField(targetType="Plant") @BelongsTo(targetName = "plantID", targetNames = {"plantID"}, type = Plant.class) Plant plant;
   private final @ModelField(targetType="Operator") @BelongsTo(targetName = "operatorID", targetNames = {"operatorID"}, type = Operator.class) Operator operator;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
-  public String resolveIdentifier() {
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
     return id;
   }
   
@@ -236,6 +239,22 @@ public final class DoseEntry implements Model {
     private CalibrationEntry calibrationEntry;
     private Plant plant;
     private Operator operator;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, Temporal.DateTime createdAt, ChemicalType chemicalType, Double targetDose, Double updatedSliderPosition, Double updatedFlowRate, CalibrationEntry calibrationEntry, Plant plant, Operator operator) {
+      this.id = id;
+      this.createdAt = createdAt;
+      this.chemicalType = chemicalType;
+      this.targetDose = targetDose;
+      this.updatedSliderPosition = updatedSliderPosition;
+      this.updatedFlowRate = updatedFlowRate;
+      this.calibrationEntry = calibrationEntry;
+      this.plant = plant;
+      this.operator = operator;
+    }
+    
     @Override
      public DoseEntry build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -318,15 +337,12 @@ public final class DoseEntry implements Model {
 
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, Temporal.DateTime createdAt, ChemicalType chemicalType, Double targetDose, Double updatedSliderPosition, Double updatedFlowRate, CalibrationEntry calibrationEntry, Plant plant, Operator operator) {
-      super.id(id);
-      super.createdAt(createdAt)
-        .chemicalType(chemicalType)
-        .targetDose(targetDose)
-        .updatedSliderPosition(updatedSliderPosition)
-        .updatedFlowRate(updatedFlowRate)
-        .calibrationEntry(calibrationEntry)
-        .plant(plant)
-        .operator(operator);
+      super(id, createdAt, chemicalType, targetDose, updatedSliderPosition, updatedFlowRate, calibrationEntry, plant, operator);
+      Objects.requireNonNull(createdAt);
+      Objects.requireNonNull(chemicalType);
+      Objects.requireNonNull(targetDose);
+      Objects.requireNonNull(updatedSliderPosition);
+      Objects.requireNonNull(updatedFlowRate);
     }
     
     @Override
@@ -367,6 +383,14 @@ public final class DoseEntry implements Model {
     @Override
      public CopyOfBuilder operator(Operator operator) {
       return (CopyOfBuilder) super.operator(operator);
+    }
+  }
+  
+
+  public static class DoseEntryIdentifier extends ModelIdentifier<DoseEntry> {
+    private static final long serialVersionUID = 1L;
+    public DoseEntryIdentifier(String id) {
+      super(id);
     }
   }
   

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/FeedbackEntry.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/FeedbackEntry.java
@@ -2,6 +2,7 @@ package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.ModelIdentifier;
 
 import java.util.List;
 import java.util.UUID;
@@ -34,7 +35,9 @@ public final class FeedbackEntry implements Model {
   private final @ModelField(targetType="Plant") @BelongsTo(targetName = "plantID", targetNames = {"plantID"}, type = Plant.class) Plant plant;
   private final @ModelField(targetType="Operator") @BelongsTo(targetName = "operatorID", targetNames = {"operatorID"}, type = Operator.class) Operator operator;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
-  public String resolveIdentifier() {
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
     return id;
   }
   
@@ -167,6 +170,18 @@ public final class FeedbackEntry implements Model {
     private String feedback;
     private Plant plant;
     private Operator operator;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, Temporal.DateTime createdAt, String feedback, Plant plant, Operator operator) {
+      this.id = id;
+      this.createdAt = createdAt;
+      this.feedback = feedback;
+      this.plant = plant;
+      this.operator = operator;
+    }
+    
     @Override
      public FeedbackEntry build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -218,11 +233,9 @@ public final class FeedbackEntry implements Model {
 
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, Temporal.DateTime createdAt, String feedback, Plant plant, Operator operator) {
-      super.id(id);
-      super.createdAt(createdAt)
-        .feedback(feedback)
-        .plant(plant)
-        .operator(operator);
+      super(id, createdAt, feedback, plant, operator);
+      Objects.requireNonNull(createdAt);
+      Objects.requireNonNull(feedback);
     }
     
     @Override
@@ -243,6 +256,14 @@ public final class FeedbackEntry implements Model {
     @Override
      public CopyOfBuilder operator(Operator operator) {
       return (CopyOfBuilder) super.operator(operator);
+    }
+  }
+  
+
+  public static class FeedbackEntryIdentifier extends ModelIdentifier<FeedbackEntry> {
+    private static final long serialVersionUID = 1L;
+    public FeedbackEntryIdentifier(String id) {
+      super(id);
     }
   }
   

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/FilteredEntry.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/FilteredEntry.java
@@ -2,6 +2,7 @@ package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.ModelIdentifier;
 
 import java.util.List;
 import java.util.UUID;
@@ -36,7 +37,9 @@ public final class FilteredEntry implements Model {
   private final @ModelField(targetType="Plant") @BelongsTo(targetName = "plantID", targetNames = {"plantID"}, type = Plant.class) Plant plant;
   private final @ModelField(targetType="Operator") @BelongsTo(targetName = "operatorID", targetNames = {"operatorID"}, type = Operator.class) Operator operator;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
-  public String resolveIdentifier() {
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
     return id;
   }
   
@@ -181,6 +184,19 @@ public final class FilteredEntry implements Model {
     private String notes;
     private Plant plant;
     private Operator operator;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, Temporal.DateTime createdAt, List<Double> turbidities, String notes, Plant plant, Operator operator) {
+      this.id = id;
+      this.createdAt = createdAt;
+      this.turbidities = turbidities;
+      this.notes = notes;
+      this.plant = plant;
+      this.operator = operator;
+    }
+    
     @Override
      public FilteredEntry build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -239,12 +255,9 @@ public final class FilteredEntry implements Model {
 
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, Temporal.DateTime createdAt, List<Double> turbidities, String notes, Plant plant, Operator operator) {
-      super.id(id);
-      super.createdAt(createdAt)
-        .turbidities(turbidities)
-        .notes(notes)
-        .plant(plant)
-        .operator(operator);
+      super(id, createdAt, turbidities, notes, plant, operator);
+      Objects.requireNonNull(createdAt);
+      Objects.requireNonNull(turbidities);
     }
     
     @Override
@@ -270,6 +283,14 @@ public final class FilteredEntry implements Model {
     @Override
      public CopyOfBuilder operator(Operator operator) {
       return (CopyOfBuilder) super.operator(operator);
+    }
+  }
+  
+
+  public static class FilteredEntryIdentifier extends ModelIdentifier<FilteredEntry> {
+    private static final long serialVersionUID = 1L;
+    public FilteredEntryIdentifier(String id) {
+      super(id);
     }
   }
   

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/InflowEntry.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/InflowEntry.java
@@ -2,6 +2,7 @@ package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.ModelIdentifier;
 
 import java.util.List;
 import java.util.UUID;
@@ -36,7 +37,9 @@ public final class InflowEntry implements Model {
   private final @ModelField(targetType="Plant") @BelongsTo(targetName = "plantID", targetNames = {"plantID"}, type = Plant.class) Plant plant;
   private final @ModelField(targetType="Operator") @BelongsTo(targetName = "operatorID", targetNames = {"operatorID"}, type = Operator.class) Operator operator;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
-  public String resolveIdentifier() {
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
     return id;
   }
   
@@ -181,6 +184,19 @@ public final class InflowEntry implements Model {
     private String notes;
     private Plant plant;
     private Operator operator;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, Temporal.DateTime createdAt, Double inflowRate, String notes, Plant plant, Operator operator) {
+      this.id = id;
+      this.createdAt = createdAt;
+      this.inflowRate = inflowRate;
+      this.notes = notes;
+      this.plant = plant;
+      this.operator = operator;
+    }
+    
     @Override
      public InflowEntry build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -239,12 +255,9 @@ public final class InflowEntry implements Model {
 
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, Temporal.DateTime createdAt, Double inflowRate, String notes, Plant plant, Operator operator) {
-      super.id(id);
-      super.createdAt(createdAt)
-        .inflowRate(inflowRate)
-        .notes(notes)
-        .plant(plant)
-        .operator(operator);
+      super(id, createdAt, inflowRate, notes, plant, operator);
+      Objects.requireNonNull(createdAt);
+      Objects.requireNonNull(inflowRate);
     }
     
     @Override
@@ -270,6 +283,14 @@ public final class InflowEntry implements Model {
     @Override
      public CopyOfBuilder operator(Operator operator) {
       return (CopyOfBuilder) super.operator(operator);
+    }
+  }
+  
+
+  public static class InflowEntryIdentifier extends ModelIdentifier<InflowEntry> {
+    private static final long serialVersionUID = 1L;
+    public InflowEntryIdentifier(String id) {
+      super(id);
     }
   }
   

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/Operator.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/Operator.java
@@ -3,6 +3,7 @@ package com.amplifyframework.datastore.generated.model;
 import com.amplifyframework.core.model.annotations.HasMany;
 import com.amplifyframework.core.model.annotations.BelongsTo;
 import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.core.model.ModelIdentifier;
 
 import java.util.List;
 import java.util.UUID;
@@ -38,7 +39,9 @@ public final class Operator implements Model {
   private final @ModelField(targetType="Plant") @BelongsTo(targetName = "plantID", targetNames = {"plantID"}, type = Plant.class) Plant plant;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
-  public String resolveIdentifier() {
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
     return id;
   }
   
@@ -178,6 +181,16 @@ public final class Operator implements Model {
     private String id;
     private String name;
     private Plant plant;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, String name, Plant plant) {
+      this.id = id;
+      this.name = name;
+      this.plant = plant;
+    }
+    
     @Override
      public Operator build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -214,9 +227,8 @@ public final class Operator implements Model {
 
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, String name, Plant plant) {
-      super.id(id);
-      super.name(name)
-        .plant(plant);
+      super(id, name, plant);
+      Objects.requireNonNull(name);
     }
     
     @Override
@@ -227,6 +239,14 @@ public final class Operator implements Model {
     @Override
      public CopyOfBuilder plant(Plant plant) {
       return (CopyOfBuilder) super.plant(plant);
+    }
+  }
+  
+
+  public static class OperatorIdentifier extends ModelIdentifier<Operator> {
+    private static final long serialVersionUID = 1L;
+    public OperatorIdentifier(String id) {
+      super(id);
     }
   }
   

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/Plant.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/Plant.java
@@ -2,6 +2,7 @@ package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.annotations.HasMany;
 import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.core.model.ModelIdentifier;
 
 import java.util.List;
 import java.util.UUID;
@@ -35,7 +36,9 @@ public final class Plant implements Model {
   private final @ModelField(targetType="FeedbackEntry") @HasMany(associatedWith = "plant", type = FeedbackEntry.class) List<FeedbackEntry> feedbackEntries = null;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
-  public String resolveIdentifier() {
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
     return id;
   }
   
@@ -167,6 +170,15 @@ public final class Plant implements Model {
   public static class Builder implements NameStep, BuildStep {
     private String id;
     private String name;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+    
     @Override
      public Plant build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -196,13 +208,21 @@ public final class Plant implements Model {
 
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, String name) {
-      super.id(id);
-      super.name(name);
+      super(id, name);
+      Objects.requireNonNull(name);
     }
     
     @Override
      public CopyOfBuilder name(String name) {
       return (CopyOfBuilder) super.name(name);
+    }
+  }
+  
+
+  public static class PlantIdentifier extends ModelIdentifier<Plant> {
+    private static final long serialVersionUID = 1L;
+    public PlantIdentifier(String id) {
+      super(id);
     }
   }
   

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/RawEntry.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/RawEntry.java
@@ -2,6 +2,7 @@ package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.ModelIdentifier;
 
 import java.util.List;
 import java.util.UUID;
@@ -36,7 +37,9 @@ public final class RawEntry implements Model {
   private final @ModelField(targetType="Plant") @BelongsTo(targetName = "plantID", targetNames = {"plantID"}, type = Plant.class) Plant plant;
   private final @ModelField(targetType="Operator") @BelongsTo(targetName = "operatorID", targetNames = {"operatorID"}, type = Operator.class) Operator operator;
   private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
-  public String resolveIdentifier() {
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
     return id;
   }
   
@@ -181,6 +184,19 @@ public final class RawEntry implements Model {
     private String notes;
     private Plant plant;
     private Operator operator;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, Temporal.DateTime createdAt, Double turbidity, String notes, Plant plant, Operator operator) {
+      this.id = id;
+      this.createdAt = createdAt;
+      this.turbidity = turbidity;
+      this.notes = notes;
+      this.plant = plant;
+      this.operator = operator;
+    }
+    
     @Override
      public RawEntry build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -239,12 +255,9 @@ public final class RawEntry implements Model {
 
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, Temporal.DateTime createdAt, Double turbidity, String notes, Plant plant, Operator operator) {
-      super.id(id);
-      super.createdAt(createdAt)
-        .turbidity(turbidity)
-        .notes(notes)
-        .plant(plant)
-        .operator(operator);
+      super(id, createdAt, turbidity, notes, plant, operator);
+      Objects.requireNonNull(createdAt);
+      Objects.requireNonNull(turbidity);
     }
     
     @Override
@@ -270,6 +283,14 @@ public final class RawEntry implements Model {
     @Override
      public CopyOfBuilder operator(Operator operator) {
       return (CopyOfBuilder) super.operator(operator);
+    }
+  }
+  
+
+  public static class RawEntryIdentifier extends ModelIdentifier<RawEntry> {
+    private static final long serialVersionUID = 1L;
+    public RawEntryIdentifier(String id) {
+      super(id);
     }
   }
   


### PR DESCRIPTION
We recently found out that the AguaDatos client Android app was not synchronizing changes to the AppSync API via Amplify DataStore. This was because the AppSync API key had expired, and was set to only last for 7 days.

This PR has the following changes:
1. Configure the API key expiration time to 365 days. I did this using the `amplify api update` command and following the interactive steps.
2. `amplify pull` latest code model changes.

Note that I didn't run `amplify push`, and that we may need to manually update the API key in `amplifyconfiguration.json`.